### PR TITLE
NL query: eval framework, Gemini support, and UX fixes

### DIFF
--- a/eval_dataset.json
+++ b/eval_dataset.json
@@ -1,0 +1,202 @@
+[
+  {
+    "id": 1,
+    "question": "How many total registrations were there for race_2024?",
+    "expected_sql_pattern": "SELECT COUNT",
+    "expected_result": {"rows": 1, "value": 1162},
+    "difficulty": "easy",
+    "category": "count"
+  },
+  {
+    "id": 2,
+    "question": "How many female registrants signed up for the 5K in 2024?",
+    "expected_sql_pattern": "Sex.*F.*5K|5K.*Sex.*F",
+    "expected_result": {"rows": 1, "value": 194},
+    "difficulty": "medium",
+    "category": "filtered_count"
+  },
+  {
+    "id": 3,
+    "question": "What are the top 5 cities for race_2024?",
+    "expected_sql_pattern": "LIMIT 5",
+    "expected_result": {"rows": 5, "first_value": "Belmont"},
+    "difficulty": "medium",
+    "category": "ranking"
+  },
+  {
+    "id": 4,
+    "question": "Show me registrations by event type for race_2024",
+    "expected_sql_pattern": "GROUP BY.*event|event.*GROUP BY",
+    "expected_result": {"rows": 7},
+    "difficulty": "easy",
+    "category": "groupby"
+  },
+  {
+    "id": 5,
+    "question": "What are the total registrations for each year?",
+    "expected_sql_pattern": "UNION ALL",
+    "expected_result": {"rows": 4, "values": [881, 994, 1162, 86]},
+    "difficulty": "hard",
+    "category": "cross_table"
+  },
+  {
+    "id": 6,
+    "question": "How many male vs female registrants were there in race_2023?",
+    "expected_sql_pattern": "Sex",
+    "expected_result": {"rows": 2, "values_unordered": {"F": 468, "M": 516}},
+    "difficulty": "medium",
+    "category": "comparison"
+  },
+  {
+    "id": 7,
+    "question": "How many people registered for the 10K in 2023?",
+    "expected_sql_pattern": "10K.*race_2023|race_2023.*10K",
+    "expected_result": {"rows": 1, "value": 197},
+    "difficulty": "easy",
+    "category": "filtered_count"
+  },
+  {
+    "id": 8,
+    "question": "How many registrants were there 3 days before race_2024?",
+    "expected_sql_pattern": "date|Date",
+    "expected_result": {"rows": 1, "value": 971},
+    "difficulty": "hard",
+    "category": "date_calc"
+  },
+  {
+    "id": 9,
+    "question": "What events were available in race_2022?",
+    "expected_sql_pattern": "DISTINCT.*event|event.*DISTINCT",
+    "expected_result": {"rows": 8},
+    "difficulty": "easy",
+    "category": "distinct"
+  },
+  {
+    "id": 10,
+    "question": "Compare 5K registrations between race_2022 and race_2024",
+    "expected_sql_pattern": "5K",
+    "expected_result": {"rows": 2, "values_unordered": {"race_2022": 351, "race_2024": 425}},
+    "difficulty": "hard",
+    "category": "cross_table"
+  },
+  {
+    "id": 11,
+    "question": "How many unique events are there in race_2024?",
+    "expected_sql_pattern": "COUNT.*DISTINCT|DISTINCT.*event",
+    "expected_result": {"rows": 1, "value": 7},
+    "difficulty": "easy",
+    "category": "count"
+  },
+  {
+    "id": 12,
+    "question": "Which year had the most registrations?",
+    "expected_sql_pattern": "UNION ALL|ORDER BY",
+    "expected_result": {"rows": 1, "first_value": "race_2024"},
+    "difficulty": "hard",
+    "category": "cross_table"
+  },
+  {
+    "id": 13,
+    "question": "What percentage of race_2024 registrants signed up for the 5K?",
+    "expected_sql_pattern": "5K",
+    "expected_result": {"rows": 1, "value_approx": 36.57, "tolerance": 1.0},
+    "difficulty": "hard",
+    "category": "calculation"
+  },
+  {
+    "id": 14,
+    "question": "Show the registration count by sex for the 10K in race_2024",
+    "expected_sql_pattern": "Sex.*10K|10K.*Sex",
+    "expected_result": {"rows_gte": 2},
+    "difficulty": "medium",
+    "category": "filtered_groupby"
+  },
+  {
+    "id": 15,
+    "question": "When did registration open and close for race_2023?",
+    "expected_sql_pattern": "info.*race_2023|race_2023.*info",
+    "expected_result": {"rows": 1, "contains": ["2023-04-28", "2023-10-14"]},
+    "difficulty": "medium",
+    "category": "metadata"
+  },
+  {
+    "id": 16,
+    "question": "How many female 10K runners were there each year?",
+    "expected_sql_pattern": "UNION ALL",
+    "expected_result": {"rows": 3, "values_unordered": {"race_2022": 79, "race_2023": 78, "race_2024": 76}},
+    "difficulty": "hard",
+    "category": "cross_table_demographic"
+  },
+  {
+    "id": 17,
+    "question": "What are the top 5 cities for male 5K registrants in race_2024?",
+    "expected_sql_pattern": "Sex.*M.*5K|5K.*Sex.*M",
+    "expected_result": {"rows": 5, "first_value": "Belmont"},
+    "difficulty": "hard",
+    "category": "filtered_ranking"
+  },
+  {
+    "id": 18,
+    "question": "How many registrations were there 7 days before the race across all years?",
+    "expected_sql_pattern": "UNION ALL",
+    "expected_result": {"rows": 4, "values_unordered": {"race_2022": 658, "race_2023": 764, "race_2024": 835, "race_2025": 86}},
+    "difficulty": "hard",
+    "category": "cross_table_date_calc"
+  },
+  {
+    "id": 19,
+    "question": "Show the sex breakdown for the Kids Fun Run across all years",
+    "expected_sql_pattern": "UNION ALL",
+    "expected_result": {"rows_gte": 6},
+    "difficulty": "hard",
+    "category": "cross_table_demographic"
+  },
+  {
+    "id": 20,
+    "question": "What is the average age of 5K runners for each year?",
+    "expected_sql_pattern": "AVG.*Age|Age.*AVG",
+    "expected_result": {"rows": 3, "values_approx_unordered": {"race_2022": 36.7, "race_2023": 34.2, "race_2024": 33.7}, "tolerance": 1.0},
+    "difficulty": "hard",
+    "category": "cross_table_calculation"
+  },
+  {
+    "id": 21,
+    "question": "Which event had the most registrations in race_2023?",
+    "expected_sql_pattern": "ORDER BY.*DESC.*LIMIT 1|LIMIT 1",
+    "expected_result": {"rows": 1, "first_value": "5K"},
+    "difficulty": "medium",
+    "category": "ranking"
+  },
+  {
+    "id": 22,
+    "question": "How many people had registered 14 days before the race for each year?",
+    "expected_sql_pattern": "UNION ALL",
+    "expected_result": {"rows": 4, "values_unordered": {"race_2022": 522, "race_2023": 665, "race_2024": 747, "race_2025": 86}},
+    "difficulty": "hard",
+    "category": "cross_table_date_calc"
+  },
+  {
+    "id": 23,
+    "question": "What is the percentage of female registrants for each event in race_2024?",
+    "expected_sql_pattern": "Sex.*F|F.*Sex",
+    "expected_result": {"rows": 7},
+    "difficulty": "hard",
+    "category": "demographic_calculation"
+  },
+  {
+    "id": 24,
+    "question": "Compare Fido Mile registrations across all years",
+    "expected_sql_pattern": "Fido|fido|FIDO",
+    "expected_result": {"rows": 3, "values_unordered": {"race_2022": 122, "race_2023": 177, "race_2024": 138}},
+    "difficulty": "hard",
+    "category": "cross_table_filtered"
+  },
+  {
+    "id": 25,
+    "question": "How did male 5K registrations change from 2022 to 2024?",
+    "expected_sql_pattern": "Sex.*M.*5K|5K.*Sex.*M",
+    "expected_result": {"rows": 2},
+    "difficulty": "hard",
+    "category": "cross_table_demographic"
+  }
+]

--- a/eval_runner.py
+++ b/eval_runner.py
@@ -1,0 +1,269 @@
+"""
+Eval runner for the NL query engine.
+Runs each question in eval_dataset.json through the engine and checks results
+against expected values. Prints a scorecard at the end.
+
+Usage:
+    python eval_runner.py                    # run all
+    python eval_runner.py --ids 1 5 8        # run specific cases
+    python eval_runner.py --category hard    # filter by difficulty
+"""
+
+import json
+import re
+import sys
+import os
+import time
+import argparse
+from dotenv import load_dotenv
+
+# load .env for API key
+if os.path.exists(".env"):
+    load_dotenv()
+elif os.path.exists("../.env"):
+    load_dotenv(dotenv_path="../.env")
+
+from nl_query_engine import ask
+
+
+# Year labels: models may return "2022" or "race_2022" — both are valid
+YEAR_ALIASES = {
+    "race_2022": ["race_2022", "2022"],
+    "race_2023": ["race_2023", "2023"],
+    "race_2024": ["race_2024", "2024"],
+    "race_2025": ["race_2025", "2025"],
+}
+
+
+def _normalize_year_key(key):
+    """Map any year alias to its canonical form."""
+    for canonical, aliases in YEAR_ALIASES.items():
+        if key in aliases:
+            return canonical
+    return key
+
+
+def _build_actual_map(df):
+    """Build a key->value map from first two columns, normalizing year keys."""
+    if df.shape[1] < 2:
+        return {}
+    return {
+        _normalize_year_key(str(k)): v
+        for k, v in zip(df.iloc[:, 0].astype(str), df.iloc[:, 1])
+    }
+
+
+def check_result(expected, result):
+    """Check result against expected values. Returns (passed, details)."""
+    if result["error"]:
+        return False, f"ERROR: {result['error']}"
+
+    df = result["data"]
+    if df is None:
+        return False, "No data returned"
+
+    if df.empty:
+        return False, "Empty result set"
+
+    checks = []
+    passed = True
+
+    # check row count
+    if "rows" in expected:
+        ok = len(df) == expected["rows"]
+        checks.append(f"rows: {len(df)} {'==' if ok else '!='} {expected['rows']}")
+        if not ok:
+            passed = False
+
+    if "rows_gte" in expected:
+        ok = len(df) >= expected["rows_gte"]
+        checks.append(f"rows: {len(df)} {'>=' if ok else '<'} {expected['rows_gte']}")
+        if not ok:
+            passed = False
+
+    # check single scalar value
+    if "value" in expected:
+        actual = df.iloc[0, -1] if df.shape[1] > 1 else df.iloc[0, 0]
+        try:
+            ok = int(actual) == expected["value"]
+        except (ValueError, TypeError):
+            ok = str(actual) == str(expected["value"])
+        checks.append(f"value: {actual} {'==' if ok else '!='} {expected['value']}")
+        if not ok:
+            passed = False
+
+    # check approximate value
+    if "value_approx" in expected:
+        actual = df.iloc[0, -1] if df.shape[1] > 1 else df.iloc[0, 0]
+        tol = expected.get("tolerance", 1.0)
+        try:
+            ok = abs(float(actual) - expected["value_approx"]) <= tol
+        except (ValueError, TypeError):
+            ok = False
+        checks.append(f"value_approx: {actual} ~= {expected['value_approx']} (tol={tol}) {'OK' if ok else 'FAIL'}")
+        if not ok:
+            passed = False
+
+    # check first value in first row — accept year aliases
+    if "first_value" in expected:
+        actual = str(df.iloc[0, 0])
+        expected_val = expected["first_value"]
+        ok = actual == expected_val
+        if not ok:
+            ok = _normalize_year_key(actual) == _normalize_year_key(expected_val)
+        checks.append(f"first_value: {actual} {'==' if ok else '!='} {expected_val}")
+        if not ok:
+            passed = False
+
+    # check unordered key-value pairs (with year alias normalization)
+    if "values_unordered" in expected:
+        expected_map = expected["values_unordered"]
+        actual_map = _build_actual_map(df)
+        for k, v in expected_map.items():
+            canonical = _normalize_year_key(k)
+            actual_v = actual_map.get(canonical)
+            try:
+                ok = int(actual_v) == v
+            except (ValueError, TypeError):
+                ok = False
+            checks.append(f"  {k}: {actual_v} {'==' if ok else '!='} {v}")
+            if not ok:
+                passed = False
+
+    # check approximate unordered key-value pairs (with year alias normalization)
+    if "values_approx_unordered" in expected:
+        expected_map = expected["values_approx_unordered"]
+        tol = expected.get("tolerance", 1.0)
+        actual_map = _build_actual_map(df)
+        for k, v in expected_map.items():
+            canonical = _normalize_year_key(k)
+            actual_v = actual_map.get(canonical)
+            try:
+                ok = abs(float(actual_v) - v) <= tol
+            except (ValueError, TypeError):
+                ok = False
+            checks.append(f"  {k}: {actual_v} ~= {v} (tol={tol}) {'OK' if ok else 'FAIL'}")
+            if not ok:
+                passed = False
+
+    # check ordered values list
+    if "values" in expected:
+        for i, v in enumerate(expected["values"]):
+            if i < len(df):
+                actual = df.iloc[i, -1] if df.shape[1] > 1 else df.iloc[i, 0]
+                try:
+                    ok = int(actual) == v
+                except (ValueError, TypeError):
+                    ok = False
+                checks.append(f"  row[{i}]: {actual} {'==' if ok else '!='} {v}")
+                if not ok:
+                    passed = False
+
+    # check contains
+    if "contains" in expected:
+        flat = df.to_string()
+        for val in expected["contains"]:
+            ok = val in flat
+            checks.append(f"contains '{val}': {'YES' if ok else 'NO'}")
+            if not ok:
+                passed = False
+
+    return passed, "; ".join(checks)
+
+
+def run_eval(dataset_path="eval_dataset.json", ids=None, difficulty=None, provider="openai"):
+    if provider == "gemini":
+        api_key = os.environ.get("GEMINI_API_KEY", "")
+        if not api_key:
+            print("ERROR: Set GEMINI_API_KEY in .env or environment")
+            sys.exit(1)
+        model = "gemini-2.5-flash"
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        if not api_key:
+            print("ERROR: Set OPENAI_API_KEY in .env or environment")
+            sys.exit(1)
+        model = "gpt-4o-mini"
+
+    print(f"Provider: {provider} | Model: {model}\n")
+
+    with open(dataset_path) as f:
+        cases = json.load(f)
+
+    if ids:
+        cases = [c for c in cases if c["id"] in ids]
+    if difficulty:
+        cases = [c for c in cases if c["difficulty"] == difficulty]
+
+    results = []
+    total = len(cases)
+    passed_count = 0
+
+    print(f"Running {total} eval cases...\n")
+    print("=" * 70)
+
+    for case in cases:
+        qid = case["id"]
+        question = case["question"]
+        print(f"\n[Q{qid}] {question}")
+        print(f"  difficulty: {case['difficulty']}  category: {case['category']}")
+
+        result = ask(question, api_key, model=model, provider=provider)
+
+        # respect rate limits for free tier
+        if provider == "gemini":
+            time.sleep(13)
+
+        if result["sql"]:
+            print(f"  SQL: {result['sql'][:120]}...")
+
+        passed, details = check_result(case["expected_result"], result)
+
+        # also check SQL pattern if provided
+        sql_ok = True
+        if case.get("expected_sql_pattern") and result["sql"]:
+            sql_ok = bool(re.search(case["expected_sql_pattern"], result["sql"], re.IGNORECASE))
+            if not sql_ok:
+                print(f"  SQL pattern '{case['expected_sql_pattern']}' NOT matched")
+
+        overall = passed and sql_ok
+        status = "PASS" if overall else "FAIL"
+        print(f"  {status}: {details}")
+
+        if overall:
+            passed_count += 1
+
+        results.append({
+            "id": qid,
+            "question": question,
+            "passed": overall,
+            "sql": result.get("sql"),
+            "details": details,
+        })
+
+    print("\n" + "=" * 70)
+    print(f"\nSCORECARD: {passed_count}/{total} passed ({100*passed_count/total:.0f}%)")
+
+    # breakdown by difficulty
+    for diff in ["easy", "medium", "hard"]:
+        subset = [c for c in cases if c["difficulty"] == diff]
+        subset_passed = sum(1 for c, r in zip(cases, results) if c["difficulty"] == diff and r["passed"])
+        if subset:
+            print(f"  {diff}: {subset_passed}/{len(subset)}")
+
+    # save results
+    results_file = f"eval_results_{provider}.json"
+    with open(results_file, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nDetailed results saved to {results_file}")
+
+    return passed_count, total
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ids", nargs="+", type=int, help="Run specific case IDs")
+    parser.add_argument("--difficulty", choices=["easy", "medium", "hard"])
+    parser.add_argument("--provider", choices=["openai", "gemini"], default="openai")
+    args = parser.parse_args()
+    run_eval(ids=args.ids, difficulty=args.difficulty, provider=args.provider)

--- a/nl_query_engine.py
+++ b/nl_query_engine.py
@@ -74,6 +74,12 @@ def get_db_schema() -> str:
             except Exception:
                 pass
             try:
+                cursor.execute(f"SELECT DISTINCT Sex FROM [{safe_table}] LIMIT 10")
+                sexes = [row[0] for row in cursor.fetchall()]
+                sample_info += f"\n  Sex values: {sexes} (M=Male, F=Female, N=Non-binary, U=Unknown)"
+            except Exception:
+                pass
+            try:
                 cursor.execute(f"SELECT Date FROM [{safe_table}] LIMIT 1")
                 date_sample = cursor.fetchone()
                 if date_sample:
@@ -129,7 +135,7 @@ DATABASE SCHEMA:
 """
 
 
-def generate_sql(question: str, api_key: str, model: str = "gpt-4o-mini") -> str:
+def generate_sql(question: str, api_key: str, model: str = "gpt-4o-mini", provider: str = "openai") -> str:
     """
     Uses an LLM to translate a natural language question into a SQL query.
 
@@ -141,7 +147,14 @@ def generate_sql(question: str, api_key: str, model: str = "gpt-4o-mini") -> str
     The user can override to gpt-4o for harder questions if needed.
     """
     schema = get_db_schema()
-    client = OpenAI(api_key=api_key)
+
+    if provider == "gemini":
+        client = OpenAI(
+            api_key=api_key,
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+        )
+    else:
+        client = OpenAI(api_key=api_key)
 
     response = client.chat.completions.create(
         model=model,
@@ -224,7 +237,7 @@ def execute_query(sql: str) -> pd.DataFrame:
         conn.close()
 
 
-def ask(question: str, api_key: str, model: str = "gpt-4o-mini") -> dict:
+def ask(question: str, api_key: str, model: str = "gpt-4o-mini", provider: str = "openai") -> dict:
     """
     End-to-end: question in, structured result out.
 
@@ -236,7 +249,7 @@ def ask(question: str, api_key: str, model: str = "gpt-4o-mini") -> dict:
     - chart_hint: suggestion for what visualization to use
     """
     try:
-        sql = generate_sql(question, api_key, model)
+        sql = generate_sql(question, api_key, model, provider)
     except Exception as e:
         return {
             "question": question,

--- a/pages/nl_query.py
+++ b/pages/nl_query.py
@@ -23,8 +23,11 @@ api_key = os.environ.get("OPENAI_API_KEY", "")
 if not api_key:
     entered_key = st.text_input("OpenAI API Key", type="password")
     if entered_key:
-        # persist to .env so it's loaded automatically next time
-        env_path = "../.env" if os.path.exists("../.env") else ".env"
+        # persist to .env — use same resolution as load_credentials()
+        project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        env_path = os.path.join(project_root, ".env")
+        if not os.path.exists(env_path):
+            env_path = os.path.join(project_root, "..", ".env")
         with open(env_path, "a") as f:
             f.write(f"\nOPENAI_API_KEY={entered_key}\n")
         os.environ["OPENAI_API_KEY"] = entered_key

--- a/pages/nl_query.py
+++ b/pages/nl_query.py
@@ -17,15 +17,23 @@ check_requirements_installed()
 if not authenticate_user():
     st.stop()
 
-# api key check
+# api key check — load from .env so user only enters once ever
 api_key = os.environ.get("OPENAI_API_KEY", "")
 
 if not api_key:
-    api_key = st.text_input("OpenAI API Key", type="password")
+    entered_key = st.text_input("OpenAI API Key", type="password")
+    if entered_key:
+        # persist to .env so it's loaded automatically next time
+        env_path = "../.env" if os.path.exists("../.env") else ".env"
+        with open(env_path, "a") as f:
+            f.write(f"\nOPENAI_API_KEY={entered_key}\n")
+        os.environ["OPENAI_API_KEY"] = entered_key
+        st.rerun()
+    else:
+        st.write("Enter your OpenAI API key above to get started.")
+        st.stop()
+    api_key = entered_key
 
-if not api_key:
-    st.write("Enter your OpenAI API key above to get started.")
-    st.stop()
 
 # model selection
 model = st.selectbox(
@@ -50,21 +58,38 @@ cols = st.columns(3)
 for i, example in enumerate(examples):
     with cols[i % 3]:
         if st.button(example, key=f"example_{i}", use_container_width=True):
-            st.session_state["nl_question"] = example
+            st.session_state["prefill_question"] = example
+            st.rerun()
 
 # question input
 st.subheader('your question')
 
+# if an example was clicked, pre-fill the text box (but don't auto-run)
+prefill = st.session_state.pop("prefill_question", None)
+if prefill:
+    st.session_state["question_input"] = prefill
+    st.session_state["just_prefilled"] = True
+
+def _on_input_change():
+    st.session_state["input_submitted"] = True
+
 question = st.text_input(
     'Ask a question about the race data:',
-    value=st.session_state.get("nl_question", ""),
     placeholder="e.g., How many people registered for the 5K in 2024?",
     key="question_input",
+    on_change=_on_input_change,
 )
 
 run_query = st.button("Ask", type="primary", use_container_width=True)
 
-# query execution and results
+# on_change fires for both Enter and prefill, so skip if we just prefilled
+if st.session_state.pop("just_prefilled", False):
+    st.session_state.pop("input_submitted", None)
+    run_query = False
+
+if st.session_state.pop("input_submitted", False):
+    run_query = True
+
 if run_query and question:
     with st.spinner("Translating your question and querying the database..."):
         result = ask(question, api_key, model)


### PR DESCRIPTION
## Summary
- **UX fixes**: Example question buttons now prefill without auto-running; Enter key submits queries; API key persists to `.env` so it's only entered once
- **Schema improvement**: Added Sex column sample values to LLM prompt, fixing M/F mismatch errors (GPT-4o-mini: 44% → 52%)
- **Gemini support**: Added Gemini provider via OpenAI-compatible API (`--provider gemini`)
- **Eval framework**: 25 test cases (easy/medium/hard) with `eval_runner.py` for baseline comparison across providers

## Baseline Results
| | GPT-4o-mini | Gemini 2.5 Flash |
|---|---|---|
| Overall | 13/25 (52%) | 12/25 (48%) |
| Easy | 4/5 | 3/5 |
| Medium | 4/6 | 4/6 |
| Hard | 5/14 | 5/14 |

## Test plan
- [ ] Run `python eval_runner.py` to verify OpenAI baseline
- [ ] Run `python eval_runner.py --provider gemini` to verify Gemini baseline
- [ ] Test example question buttons in Streamlit UI (should prefill, not auto-run)
- [ ] Test Enter key submits query
- [ ] Verify API key persists across page navigations

🤖 Generated with [Claude Code](https://claude.com/claude-code)